### PR TITLE
Detect chromedriver when its in PATH

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -72,7 +72,7 @@ def fetch_activation_bytes(username, password, options):
         elif os.path.isfile("/usr/local/bin/chromedriver"):  # macOS + Homebrew
             chromedriver_path = "/usr/local/bin/chromedriver"
         else:
-            chromedriver_path = "./chromedriver"
+            chromedriver_path = "chromedriver"
 
 
         driver = webdriver.Chrome(chrome_options=opts,


### PR DESCRIPTION
Remove the "./" before "chromedriver" in the default case. This allows
the script to work when the chromedriver binary is somewhere in PATH,
but, not in one of the enumerated locations, and not in CWD.