### PR TITLE
allow any python version in shebang

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import os
 import sys


### PR DESCRIPTION
Now that the script supports any python 2 and 3, fix the shebang to call whatever version the user has configured on the path.

Note: Likely need to apply this change to other files, too.